### PR TITLE
fix: tidy project info panel and tweak projectTab logic

### DIFF
--- a/core/components/layout/project/LvProjectPanelItem.vue
+++ b/core/components/layout/project/LvProjectPanelItem.vue
@@ -6,18 +6,22 @@
       :data-cy="`project__${name}`"
       class="relative p-2 flex flex-col justify-center px-4 focus-visible:bg-sky focus-visible:text-white outline-none"
       :class="{
-          'text-md text-white mx-1 mb-[2px] first-of-type:mt-1 last-of-type:mb-1 bg-indigo items-start' : isExpanded,
-          'flex-1 text-center bg-gray-50 border-t border-t-gray-200 items-center first-of-type:border-none' : !isExpanded,
-          'text-gray-500' : !isExpanded && !isActive,
-          'border-r-4 border-indigo text-indigo' : !isExpanded && isActive,
-        }">
-      <LvTabText :is-expanded="isExpanded">{{ $L(`project_${name}`) }}</LvTabText>
-
+        'text-md text-white mx-1 mb-[2px] first-of-type:mt-1 last-of-type:mb-1 bg-indigo items-start':
+          isExpanded,
+        'flex-1 text-center bg-gray-50 border-t border-t-gray-200 items-center first-of-type:border-none':
+          !isExpanded,
+        'text-gray-500': !isExpanded && !isActive,
+        'border-r-4 border-indigo text-indigo': !isExpanded && isActive,
+      }"
+    >
+      <LvTabText :is-expanded="isExpanded">{{
+        $L(`project_${name}`)
+      }}</LvTabText>
     </DisclosureButton>
 
     <div v-show="isActive && isExpanded" class="overflow-y-auto bg-gray-50">
       <DisclosurePanel static>
-        <slot/>
+        <slot />
       </DisclosurePanel>
     </div>
   </Disclosure>
@@ -30,7 +34,6 @@ import { computed } from 'vue';
 import LvTabText from '../../ui/LvTabText.vue';
 import { useRoute, useRouter } from 'vue-router';
 
-
 const props = defineProps({
   name: String,
 });
@@ -40,12 +43,14 @@ const route = useRoute();
 const leviate = useLeviateStore();
 
 const isExpanded = computed(() => leviate.panels.project.isExpanded);
-const isActive = computed(() => leviate.panels.project.activeItem === props.name);
+const isActive = computed(
+  () => leviate.panels.project.activeItem === props.name
+);
 
 function onClick(name) {
   if (isActive.value) {
     leviate.setActiveProjectItem(null);
-    const { projectTab, ...query } = route.query;
+    const query = { ...route.query, projectTab: 'none' };
     router.replace({ query });
   } else {
     leviate.setActiveProjectItem(name);

--- a/core/components/layout/project/info/LvProjectInfo.vue
+++ b/core/components/layout/project/info/LvProjectInfo.vue
@@ -1,26 +1,29 @@
 <template>
-  <div class="h-full p-4">
+  <div class="h-full p-4 flex flex-col">
+    <h4 class="text-sky-dark font-bold mb-2 text-base">
+      {{ $L('project_info_heading') }}
+    </h4>
 
-    <div class="text-sky-dark font-bold text-lg mb-2">{{ $L('project_info_heading') }}</div>
-
-    <div class="ml-2">
-      <div class="flex justify-between mb-1 text-gray-500 text-base font-bold border-b pb-1 mb-2">
-        <div>{{ name }}</div>
-        <div>#{{ number }}</div>
-      </div>
-
-      <LvAddress :data="project.address"
-                 :fields="['name', 'address', 'city', 'postalCode', 'country']"
-                 :bold-fields="['name']"/>
-
+    <div
+      class="flex justify-between mb-1 text-gray-500 font-bold border-b py-1 mb-2"
+    >
+      <div>{{ name }}</div>
+      <div>#{{ number }}</div>
     </div>
+
+    <LvAddress
+      :data="project.address"
+      :fields="['name', 'address', 'city', 'postalCode', 'country']"
+      :bold-fields="['name']"
+    />
 
     <LvClientInfo v-if="customer" v-bind="customer" />
 
     <div class="text-right">
-      <CButton color="sky" size="sm" @click="openProjectSettings">{{ $L('edit') }}</CButton>
+      <CButton color="sky" size="sm" @click="openProjectSettings">{{
+        $L('edit')
+      }}</CButton>
     </div>
-
   </div>
 </template>
 
@@ -30,11 +33,12 @@ import LvAddress from './LvAddress.vue';
 import LvClientInfo from './LvClientInfo.vue';
 
 const $host = useHost();
+
 const { project, customer, origin } = $host.meta;
 const { name, number } = project;
 
 function openProjectSettings() {
   const projectEditUrl = `${origin}/projects/${[project.id]}`;
-  window.open(projectEditUrl)
+  window.open(projectEditUrl);
 }
 </script>


### PR DESCRIPTION
Tweaked logic around active projectTabs. 
Revised project info component to have layout more suited to other such panels.

OLD:
![live](https://github.com/leviat-tech/leviate/assets/55240533/0b4f9814-049c-4069-a8bf-d09c1cea6ea2)


NEW:
![new](https://github.com/leviat-tech/leviate/assets/55240533/ba95d10c-3f11-45df-b695-9f51ed7985b0)
