### PR TITLE
fix: set min width on LvPanel

### DIFF
--- a/core/components/ui/LvPanel.vue
+++ b/core/components/ui/LvPanel.vue
@@ -2,7 +2,7 @@
   <div class="bg-white h-full flex flex-col justify-between overflow-hidden"
        :data-cy="`panel__${panelId}`"
        :class="isExpanded || 'flex-none'"
-       :style="`width:${widthValue}px`">
+       :style="`min-width:${widthValue}px`">
 
     <!-- Panel content -->
     <div class="flex-1 overflow-hidden">


### PR DESCRIPTION
LvPanel had a fixed  non-flex width non-flex. As such, when the screen width is too low, the entire project panel could be unusable or even entirely hidden. This has been revised to be min-width ensuring the panels stay at least the specified width. When testing, please bear in mind it has been agreed to "rob" the viewport and allocate space to functional panels such as the project one.

Here is this in the context of Column Shoes:

OLD:
![old](https://github.com/leviat-tech/leviate/assets/55240533/b15eaabf-7fa7-430b-b0fe-5003ea124098)



NEW:
![new](https://github.com/leviat-tech/leviate/assets/55240533/3204b097-2f8e-4446-9ada-1f045bb043d5)
