### PR TITLE
feat: configure tabs for results panel

### DIFF
--- a/core/components/layout/LvResultsPanel.vue
+++ b/core/components/layout/LvResultsPanel.vue
@@ -1,13 +1,17 @@
 <template>
   <LvPanel :expanded="width" panelId="results" :flip="true" :class="{ 'opacity-50' : disabled }" :disabled="disabled">
-      <button v-if="!isExpanded"
-              class="flex h-full w-full items-center justify-center bg-gray-100 hover:bg-gray-200 focus-visible:bg-sky focus-visible:text-white outline-none"
-              :class="disabled && 'cursor-default'"
-              @click="togglePanel"
-      >
-        <LvTabText :is-expanded="isExpanded">Results</LvTabText>
-      </button>
-      <slot v-else />
+    <button v-if="!isExpanded"
+            class="flex h-full w-full items-center justify-center bg-gray-100 hover:bg-gray-200 focus-visible:bg-sky focus-visible:text-white outline-none"
+            :class="disabled && 'cursor-default'"
+            @click="togglePanel"
+    >
+      <LvTabText :is-expanded="isExpanded">Results</LvTabText>
+    </button>
+    <div v-else-if="tabs" class="h-full flex flex-col justify-start -mx-px">
+      <LvInputToolbar :tabs="tabs" panel="results" />
+      <slot />
+    </div>
+    <slot v-else />
   </LvPanel>
 </template>
 
@@ -16,6 +20,7 @@ import { useLeviateStore } from '../../store/leviate';
 import LvPanel from '../ui/LvPanel.vue';
 import { computed } from 'vue';
 import LvTabText from '../ui/LvTabText.vue';
+import LvInputToolbar from './input/LvInputToolbar.vue';
 
 const store = useLeviateStore();
 
@@ -29,7 +34,6 @@ const togglePanel = () => {
     isExpanded.value = !isExpanded.value
   }
 }
-
 const props = defineProps({
   width: {
     type: Number,
@@ -38,8 +42,9 @@ const props = defineProps({
   disabled: {
     type: Boolean,
     default: false,
+  },
+  tabs: {
+    type: Array,
   }
 });
-
-
 </script>

--- a/core/components/layout/input/LvInputTabPanel.vue
+++ b/core/components/layout/input/LvInputTabPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="store.activeInputTab === tabId">
+  <div v-if="store.panels[panel].activeTab === tabId">
     <slot />
   </div>
 </template>
@@ -9,6 +9,10 @@ import { useLeviateStore } from '@crhio/leviate/store/leviate.js';
 
 const props = defineProps({
   tabId: String,
+  panel: {
+    type: String,
+    default: 'input'
+  }
 });
 
 const store = useLeviateStore();

--- a/core/components/layout/input/LvInputToolbar.vue
+++ b/core/components/layout/input/LvInputToolbar.vue
@@ -38,23 +38,34 @@ const props = defineProps({
   tabs: {
     type: Array,
     default: ['input'],
+  },
+  panel: {
+    type: String,
+    default: 'input'
   }
 })
 
 const store = useLeviateStore();
+const activePanel = props.panel;
 
-const isExpanded = computed(() => store.panels.input.isExpanded);
-const activeTab = computed(() => store.activeInputTab);
+const isExpanded = computed(() => store.panels[activePanel].isExpanded);
+const activeTab = computed(() => store.panels[activePanel].activeTab);
 
 const clickTab = (tabId) => {
-  store.panels.input.activeTab = tabId;
+  store.panels[activePanel].activeTab = tabId;
 
   if (!store.panels.input.isExpanded) {
-    store.panels.input.isExpanded = true;
+    store.panels[activePanel].isExpanded = true;
   }
 
-  const query = { ...route.query, inputTab: tabId }
-  router.push({ query })
+  const query = { ...route.query };
+
+  if (activePanel === 'input') {
+    query.inputTab = tabId;
+  } else {
+    query.resultTab = tabId;
+  }
+  router.push({ query });
 }
 
 if (props.tabs.length > 0 && !props.tabs.includes(activeTab.value)) {

--- a/core/store/leviate.js
+++ b/core/store/leviate.js
@@ -13,6 +13,7 @@ export const useLeviateStore = defineStore('leviate', {
       },
       results: {
         isExpanded: false,
+        activeTab: null,
       },
       validation: {
         isExpanded: true


### PR DESCRIPTION
This PR is to enable separate tab group for the results panel.

In the MSD-ui we have requirement to have tabs in the results panel. If we try to use tabs with the current configuration we have this issues

https://github.com/leviat-tech/leviate/assets/127110852/ede93f55-0493-4b5e-acc7-e001c8b324a2


https://github.com/leviat-tech/leviate/assets/127110852/8ee1757d-29b1-4d8f-bf39-d7daff11db99


So the idea is to enable the <LvResultsPanel> component to receive the "tabs" prop and if that is passed to display the tabs. Also we would need to pass new prop 'panel' to the <LvInputTabPanel>  component in order to get the correct active tab for the results. 
