### PR TITLE
fix: show correct error messages for array items

### DIFF
--- a/core/concreteOptions.js
+++ b/core/concreteOptions.js
@@ -23,7 +23,7 @@ const parseInputId = (inputId) => {
 
 
 const parseOptionsFromInputId = (inputId) => {
-  const {instance, path} = parseInputId(inputId);
+  const { instance, path } = parseInputId(inputId);
 
   return instance.coercedSchema.reach(path).options();
 }
@@ -57,7 +57,12 @@ export default {
     if (!id) return;
 
     const { inputStatus } = useMessageStore();
-    const [entityId, path] = id.split(':');
+    let [entityId, path] = id.split(':');
+
+    if (path) {
+      path = path.replaceAll('.[', '[')
+    }
+
     const errors = inputStatus[entityId]?.[path];
 
     if (!errors) return;


### PR DESCRIPTION
In our message store for array items like brackets we keep key in format : " brackets[0].number_of_bolts "
In CIC app to set brackets we use id in format: " brackets.[0].number_of_bolts "
This change keeps values and validation in sync