### PR TITLE
fix: modify the property path of model for array items to find error messages created by schema validation

### DIFF
--- a/core/concreteOptions.js
+++ b/core/concreteOptions.js
@@ -14,15 +14,13 @@ const parseInputId = (inputId) => {
     return {};
   }
 
-  let [entityId, path] = segments;
+  const [entityId, path] = segments;
   const store = useRootStore();
   // If the entityId is a uuid then get the instance from the entities store
   // Otherwise entityId is a store module
   const isModel = validate(entityId);
   const instance = isModel ? store.getEntityById(entityId) : store.modules[entityId]?.();
-  if (path) {
-    path = path.replaceAll('.[', '[')
-  }
+
   return { instance, path, isModel };
 }
 
@@ -66,7 +64,8 @@ export default {
 
     if (!instance || !isModel) return;
 
-    const error = instance.getInputErrorByPath(path);
+    const errorPath = path?.replaceAll('.[', '[');
+    const error = instance.getInputErrorByPath(errorPath);
 
     if (!error) return;
 


### PR DESCRIPTION
validation errors created by schema for array items like brackets have a path like: "brackets[0].number_of_bolts "
which is different from the property path used in model e.g.: "brackets.[0].number_of_bolts "
to find the input errors in model and to display in UI,  we need to modify the path in "inputGetStatus" function
![image](https://github.com/user-attachments/assets/ab0e25ad-7b6d-431c-a07c-6ab238b07315)
