### PR TITLE
feat: pass last non error update to offspring models

### DIFF
--- a/core/BaseModel.js
+++ b/core/BaseModel.js
@@ -29,9 +29,10 @@ class BaseModel extends Entity {
 
   static afterUpdate(instance) {
     if (instance.lastUpdatedFields.includes('errors')) return;
+    const lastNonErorUpdate = instance.lastUpdatedFields.reduce((patch, field) => ({ ...patch, [field]: instance[field] }),{})
 
     instance.$validate();
-    instance.afterUpdate?.();
+    instance.afterUpdate?.(lastNonErorUpdate);
   }
 
   $validate() {


### PR DESCRIPTION
related to work done on [SPA-352](https://crhleviat.atlassian.net/browse/SPA-352)
Note: right now every latest updated field  of an instance is an 'error' field due to instance.$validate(), which clearInputErrors() as a first step. That makes tracking updates in Basemodel's offspring models' instances afterUpdate method problematic. Assuming that errors should be treated on a Basemodel level, offspring's instance afterUpdate probably cares more about last non error update that was successful 

[SPA-352]: https://crhleviat.atlassian.net/browse/SPA-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ