### PR TITLE
feat: enable setting locale from host selected language

### DIFF
--- a/core/createApp.js
+++ b/core/createApp.js
@@ -1,7 +1,7 @@
 import { createApp as _createApp } from 'vue';
 import Concrete from '@crhio/concrete';
 import HostPlugin, { useHost, hostIsConnected } from './plugins/host';
-import LocalizePlugin from './plugins/localize';
+import LocalizePlugin, { useLocalize } from './plugins/localize';
 import { createStore, initializeStore } from './store';
 import { createRouter } from './router';
 import concreteDefaultOptions from './concreteOptions';
@@ -69,6 +69,7 @@ export async function createApp(projectConfig, Root, isStandalone) {
   const host = useHost()
   const initialState = await host.getState();
   const initialUrl = await host.getUrl();
+  host.meta?.hostLanguage && useLocalize().setLocale(host.meta.hostLanguage);
 
   initializeStore(initialState, migrations, models);
 


### PR DESCRIPTION
The idea is to pass the host language from the design studio to the leviate and set it as a locale value if it is supported by the app.
So we would pass it from the design studio like this
![Screenshot 2024-11-19 at 13 38 57](https://github.com/user-attachments/assets/d37bf89a-5708-4754-afa1-f5016c44003d)
Design Studio PR: https://github.com/leviat-tech/design-studio/pull/231