### PR TITLE
feat: add shared config loader

### DIFF
--- a/core/getSharedConfig.js
+++ b/core/getSharedConfig.js
@@ -1,0 +1,11 @@
+const translationPlugin = require("./plugins/translation");
+const merge = require('lodash/merge');
+
+export default function getSharedConfig(translationsName, projectConfig) {
+  const sharedConfig = {
+    // TODO: add shared config data
+    plugins: [translationPlugin(translationsName)]
+  }
+  // return merged config
+  return merge(sharedConfig, projectConfig)
+}

--- a/core/getSharedConfig.js
+++ b/core/getSharedConfig.js
@@ -1,11 +1,75 @@
-const translationPlugin = require("./plugins/translation");
+const path = require('path');
 const merge = require('lodash/merge');
+const vue = require('@vitejs/plugin-vue');
+const svgLoader = require('vite-svg-loader');
+const getDefaultTemplateCompilerOptions = require('./server/defaultTemplateCompilerOptions');
+const manifestPlugin = require('./server/manifestPlugin');
+const translationPlugin = require('./server/translation');
 
-export default function getSharedConfig(translationsName, projectConfig) {
+/**
+ * Ensure page does a full reload when 3d files are updated
+ * as hot uploading not currently supported
+ * @return {{handleHotUpdate(*): void, name: string}}
+ */
+const threeReloadPlugin = () => ({
+  name: 'three-reload',
+  handleHotUpdate(ctx) {
+    if (ctx.file.search('3dmodel') > -1) {
+      ctx.server.ws.send({ type: 'full-reload' });
+    }
+  },
+});
+
+module.exports = function getSharedConfig({ projectName, mode, dir, projectConfig = {} }) {
   const sharedConfig = {
-    // TODO: add shared config data
-    plugins: [translationPlugin(translationsName)]
+    resolve: {
+      alias: {
+        '~': `${path.resolve(dir)}`,
+        '@': `${path.resolve(dir, 'src')}`,
+        '@crhio/leviate': '/node_modules/@crhio/leviate/core',
+      },
+    },
+
+    base: './',
+
+    optimizeDeps: {
+      exclude: ['@headlessui/vue', '@crhio/leviate', '@crhio/normie', 'pinia', 'vue-router', 'vue'],
+      include: ['@crhio/leviate > axios', 'axios/lib/adapters/http'],
+    },
+
+    plugins: [
+      svgLoader(),
+      manifestPlugin(),
+      threeReloadPlugin(),
+      vue(getDefaultTemplateCompilerOptions(mode)),
+      translationPlugin(projectName)
+    ],
+
+    build: {
+      minify: false,
+    },
+
+    server: {
+      port: 8080,
+      proxy: {
+        '/api': {
+          target: process.env.SERVICE_URL,
+          headers: {
+            'x-service-key': process.env.SERVICE_KEY,
+          },
+          changeOrigin: true,
+        },
+      },
+    },
+
+    preview: {
+      port: 8081,
+    },
+
+    test: {
+      globals: true,
+    },
   }
-  // return merged config
+
   return merge(sharedConfig, projectConfig)
 }

--- a/core/getSharedConfig.js
+++ b/core/getSharedConfig.js
@@ -20,12 +20,12 @@ const threeReloadPlugin = () => ({
   },
 });
 
-module.exports = function getSharedConfig({ projectName, mode, dir, projectConfig = {} }) {
+module.exports = function getSharedConfig({ mode, projectConfig = {} }) {
   const sharedConfig = {
     resolve: {
       alias: {
-        '~': `${path.resolve(dir)}`,
-        '@': `${path.resolve(dir, 'src')}`,
+        '~': `${path.resolve(process.cwd())}`,
+        '@': `${path.resolve(process.cwd(), 'src')}`,
         '@crhio/leviate': '/node_modules/@crhio/leviate/core',
       },
     },
@@ -42,7 +42,7 @@ module.exports = function getSharedConfig({ projectName, mode, dir, projectConfi
       manifestPlugin(),
       threeReloadPlugin(),
       vue(getDefaultTemplateCompilerOptions(mode)),
-      translationPlugin(projectName)
+      translationPlugin()
     ],
 
     build: {

--- a/core/plugins/translation.js
+++ b/core/plugins/translation.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const axios = require('axios');
+const merge = require('lodash/merge');
+
+const translationUrl = 'https://leviatdesignstudio.com/service/translations/api/translations'; // TODO: get the url from env
+const localesFolderName = 'src/locales';
+
+export default async function translationPlugin(projectName) {
+  try {
+    if (!fs.existsSync(localesFolderName)) {
+      fs.mkdirSync(localesFolderName);
+    }
+    if (!projectName.length) {
+      throw new Error(
+        'Please specify the app name in the script by adding argument. Example build:translation "Project Name"',
+      );
+    }
+  } catch (err) {
+    console.error(err);
+  }
+
+  let jsonData = {};
+  const fileName = `${localesFolderName}/index.json`;
+  const languages_data = await axios.get(translationUrl);
+  const languages = languages_data.data.filter(app => app.name === projectName[0])[0].dictionaries;
+  const countries = languages_data.data.filter(app => app.name === 'Countries')[0].dictionaries;
+
+  Object.keys(languages).forEach(translation => {
+    if (Object.keys(languages[translation]).length !== 0) {
+      jsonData = {
+        ...jsonData,
+        [translation]: merge(languages[translation], countries[translation]),
+      };
+    }
+  });
+  fs.writeFileSync(fileName, JSON.stringify(jsonData));
+}

--- a/core/server/translation.js
+++ b/core/server/translation.js
@@ -1,17 +1,18 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const axios = require('axios');
 const merge = require('lodash/merge');
 
-const translationUrl = 'https://leviatdesignstudio.com/service/translations/api/translations';
+const translationUrl = process.env.VITE_TRANSLATE_BASE_URL;
 const localesFolderName = 'src/locales';
 
-module.exports = async function translationPlugin(projectName) {
-  console.log('translationPlugin')
+module.exports = async function translationPlugin() {
+  const { name } = fs.readJsonSync(`${process.cwd()}/manifest.json`);
+  
   try {
     if (!fs.existsSync(localesFolderName)) {
       fs.mkdirSync(localesFolderName);
     }
-    if (!projectName.length) {
+    if (!name.length) {
       throw new Error(
         'Make sure that you specify the project name in order to get translations keys',
       );
@@ -23,7 +24,7 @@ module.exports = async function translationPlugin(projectName) {
   let jsonData = {};
   const fileName = `${localesFolderName}/index.json`;
   const languages_data = await axios.get(translationUrl);
-  const languages = languages_data.data.filter(app => app.name === projectName)[0].dictionaries;
+  const languages = languages_data.data.filter(app => app.name === name)[0].dictionaries;
   const countries = languages_data.data.filter(app => app.name === 'Countries')[0].dictionaries;
 
   Object.keys(languages).forEach(translation => {

--- a/core/server/translation.js
+++ b/core/server/translation.js
@@ -2,17 +2,18 @@ const fs = require('fs');
 const axios = require('axios');
 const merge = require('lodash/merge');
 
-const translationUrl = 'https://leviatdesignstudio.com/service/translations/api/translations'; // TODO: get the url from env
+const translationUrl = 'https://leviatdesignstudio.com/service/translations/api/translations';
 const localesFolderName = 'src/locales';
 
-export default async function translationPlugin(projectName) {
+module.exports = async function translationPlugin(projectName) {
+  console.log('translationPlugin')
   try {
     if (!fs.existsSync(localesFolderName)) {
       fs.mkdirSync(localesFolderName);
     }
     if (!projectName.length) {
       throw new Error(
-        'Please specify the app name in the script by adding argument. Example build:translation "Project Name"',
+        'Make sure that you specify the project name in order to get translations keys',
       );
     }
   } catch (err) {
@@ -22,7 +23,7 @@ export default async function translationPlugin(projectName) {
   let jsonData = {};
   const fileName = `${localesFolderName}/index.json`;
   const languages_data = await axios.get(translationUrl);
-  const languages = languages_data.data.filter(app => app.name === projectName[0])[0].dictionaries;
+  const languages = languages_data.data.filter(app => app.name === projectName)[0].dictionaries;
   const countries = languages_data.data.filter(app => app.name === 'Countries')[0].dictionaries;
 
   Object.keys(languages).forEach(translation => {

--- a/core/server/translation.js
+++ b/core/server/translation.js
@@ -6,13 +6,13 @@ const translationUrl = process.env.VITE_TRANSLATE_BASE_URL;
 const localesFolderName = 'src/locales';
 
 module.exports = async function translationPlugin() {
-  const { name } = fs.readJsonSync(`${process.cwd()}/manifest.json`);
+  const { translationName } = fs.readJsonSync(`${process.cwd()}/manifest.json`);
   
   try {
     if (!fs.existsSync(localesFolderName)) {
       fs.mkdirSync(localesFolderName);
     }
-    if (!name.length) {
+    if (!translationName.length) {
       throw new Error(
         'Make sure that you specify the project name in order to get translations keys',
       );
@@ -24,7 +24,7 @@ module.exports = async function translationPlugin() {
   let jsonData = {};
   const fileName = `${localesFolderName}/index.json`;
   const languages_data = await axios.get(translationUrl);
-  const languages = languages_data.data.filter(app => app.name === name)[0].dictionaries;
+  const languages = languages_data.data.filter(app => app.name === translationName)[0].dictionaries;
   const countries = languages_data.data.filter(app => app.name === 'Countries')[0].dictionaries;
 
   Object.keys(languages).forEach(translation => {


### PR DESCRIPTION
Adding getSharedConfig in order to easily share common configuration between the apps and load translations keys from the service.
Example of how it would be used for our projects in this case ColumnShoes:
![Screenshot 2025-02-13 at 12 02 35](https://github.com/user-attachments/assets/7e43b38d-b1bb-4faa-9b9c-25e85857689f)

related ticket https://crhleviat.atlassian.net/browse/DDSP-528