### PR TITLE
feat: add generic category getErrorByPath to BaseModel

### DIFF
--- a/core/BaseModel.ts
+++ b/core/BaseModel.ts
@@ -79,8 +79,13 @@ class BaseModel extends Entity {
     this.errors = reject(this.errors, { id });
   }
 
-  getInputErrorByPath(path) {
-    return find(this.errors, { category: 'input', path });
+  getErrorByPath(path: string, category = 'input') {
+    return find(this.errors, { category, path });
+  }
+
+//for backwards compatibility
+  getInputErrorByPath(path: string) {
+    this.getErrorByPath(path)
   }
 }
 


### PR DESCRIPTION
Reasoning to allow search (delete) error's categories other than 'input' (in scope of [SPA-439](https://crhleviat.atlassian.net/browse/SPA-439))

[SPA-439]: https://crhleviat.atlassian.net/browse/SPA-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ