### PR TITLE
fix: dont track transaction depth in undo stack

### DIFF
--- a/core/store/index.js
+++ b/core/store/index.js
@@ -88,7 +88,7 @@ function deepDiff(obj1, obj2) {
 
   compare(obj1, obj2);
 
-  return omit(result, 'transactionDepth');
+  return omit(result, ['newValue.transactionDepth','oldValue.transactionDepth']);
 }
 
 const initialActions = {


### PR DESCRIPTION
transaction depth wasnt being ommited properly, so after one undo the value never returned to 0, preventing commit from being triggered.