### PR TITLE
fix: omit settings changes from undo tracking

### DIFF
--- a/core/extensions/Revision.js
+++ b/core/extensions/Revision.js
@@ -1,5 +1,5 @@
 import { computed, reactive } from 'vue';
-import { each, map, set, unset } from 'lodash-es';
+import { each, map, set, unset, isEmpty } from 'lodash-es';
 
 
 class Revision {
@@ -15,6 +15,7 @@ class Revision {
 
   // save current state to undo stack
   commit(patch) {
+    if (isEmpty(patch.newValue) && isEmpty(patch.oldValue)) return
     this.undos.push(patch);
 
     // Redo is no longer possible once a new change has been made

--- a/core/extensions/Revision.js
+++ b/core/extensions/Revision.js
@@ -1,5 +1,5 @@
 import { computed, reactive } from 'vue';
-import { each, map, set, unset, isEmpty } from 'lodash-es';
+import { each, isEmpty, map, omitBy, set, unset } from 'lodash-es';
 
 
 class Revision {
@@ -15,8 +15,12 @@ class Revision {
 
   // save current state to undo stack
   commit(patch) {
-    if (isEmpty(patch.newValue) && isEmpty(patch.oldValue)) return
-    this.undos.push(patch);
+    const dontUndo = (val,key) => key.startsWith("settings.")
+    const cleanPatch = patch.map((change) => {
+      return { newValue: omitBy(change.newValue, dontUndo), oldValue: omitBy(change.oldValue, dontUndo) }
+    }).filter((change) => !isEmpty(change.newValue) || !isEmpty(change.oldValue) )
+    if (cleanPatch.length === 0) return
+    this.undos.push(cleanPatch);
 
     // Redo is no longer possible once a new change has been made
     this.redos.length = 0;

--- a/core/store/index.js
+++ b/core/store/index.js
@@ -42,6 +42,7 @@ const initialState = {
   appVersion: null,
 };
 
+//deep compare, output only the differing properties between the 2 objects, ignoring "settings" and "transactionDepth" at the top level
 function deepDiff(obj1, obj2) {
   const result = {
     oldValue: {},
@@ -86,9 +87,9 @@ function deepDiff(obj1, obj2) {
     }
   }
 
-  compare(obj1, obj2);
-
-  return omit(result, ['newValue.transactionDepth','oldValue.transactionDepth']);
+  const noTrack = ['transactionDepth','settings']
+  compare(omit(obj1,noTrack), omit(obj2,noTrack));
+  return result
 }
 
 const initialActions = {

--- a/core/store/index.js
+++ b/core/store/index.js
@@ -42,7 +42,6 @@ const initialState = {
   appVersion: null,
 };
 
-//deep compare, output only the differing properties between the 2 objects, ignoring "settings" and "transactionDepth" at the top level
 function deepDiff(obj1, obj2) {
   const result = {
     oldValue: {},
@@ -87,9 +86,9 @@ function deepDiff(obj1, obj2) {
     }
   }
 
-  const noTrack = ['transactionDepth','settings']
-  compare(omit(obj1,noTrack), omit(obj2,noTrack));
-  return result
+  compare(obj1, obj2);
+
+  return omit(result, ['newValue.transactionDepth','oldValue.transactionDepth']);
 }
 
 const initialActions = {


### PR DESCRIPTION
ignore settings in diff for undo stack
don't put no-ops onto undo stack