### PR TITLE
fix: revert changes if transaction fails

### DIFF
--- a/core/components/layout/LvLayout.vue
+++ b/core/components/layout/LvLayout.vue
@@ -32,7 +32,18 @@
         <ProjectRoot />
       </LvProjectPanel>
 
-      <div class="flex-1">
+      <div class="flex-1 relative">
+        <Transition
+          enter-from-class="-translate-y-4 opacity-0"
+          leave-to-class="-translate-y-4 opacity-0"
+        >
+          <div
+            v-if="globalMessage"
+            class="absolute z-30 bg-danger text-white py-3 px-4 inset-x-4 top-4 rounded transition">
+            {{ globalMessage }}
+          </div>
+        </Transition>
+
         <slot />
       </div>
     </div>
@@ -40,14 +51,16 @@
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue';
-import { useRootStore } from '@crhio/leviate';
+import { computed, onMounted, ref } from 'vue';
+import { useRootStore, useLeviateStore } from '@crhio/leviate';
 
 import ProjectRoot from '@/components/project/ProjectRoot.vue';
 import { LvProjectPanel } from '../';
 import LvReadOnlyBanner from './LvReadOnlyBanner.vue'
 
 const appVersionsHaveMismatch = ref(false);
+
+const globalMessage = computed(() => useLeviateStore().globalMessage);
 
 onMounted(async () => {
   appVersionsHaveMismatch.value = await useRootStore().detectAppVersionMismatch;

--- a/core/concreteOptions.js
+++ b/core/concreteOptions.js
@@ -32,7 +32,7 @@ export default {
 
     const pathSegments = path.split('.');
 
-    transact(() => {
+    transact(`Input handler (${path})`, () => {
       if (pathSegments.length === 1) {
         return set(instance, path, val);
       }

--- a/core/extensions/Revision.js
+++ b/core/extensions/Revision.js
@@ -66,7 +66,7 @@ class Revision {
       });
     });
 
-    this.store.replaceState(state);
+    this.store.replaceState(state, true);
   }
 
   // clear revision undo / redo stack

--- a/core/extensions/Revision.js
+++ b/core/extensions/Revision.js
@@ -8,19 +8,22 @@ class Revision {
     this.maxUpdates = maxUpdates;
     this.undos = reactive([]);
     this.redos = reactive([]);
+    this.transactionId = null;
 
     this.redoable = computed(() => this.redos.length > 0);
     this.undoable = computed(() => this.undos.length > 0);
   }
 
   // save current state to undo stack
-  commit(patch) {
-    const dontUndo = (val,key) => key.startsWith("settings.")
+  commit(patch, transactionId) {
+    const dontUndo = (val,key) => key.startsWith('settings.')
     const cleanPatch = patch.map((change) => {
       return { newValue: omitBy(change.newValue, dontUndo), oldValue: omitBy(change.oldValue, dontUndo) }
     }).filter((change) => !isEmpty(change.newValue) || !isEmpty(change.oldValue) )
     if (cleanPatch.length === 0) return
     this.undos.push(cleanPatch);
+
+    this.transactionId = transactionId;
 
     // Redo is no longer possible once a new change has been made
     this.redos.length = 0;

--- a/core/host-mock.js
+++ b/core/host-mock.js
@@ -2,7 +2,7 @@ import inject from '@crhio/inject';
 import logger from './extensions/logger.js';
 import { ref } from 'vue';
 import useVersions from './composables/useVersions';
-import { cloneDeep, each, set } from 'lodash-es';
+import { cloneDeep, each, set, unset } from 'lodash-es';
 import axios from 'axios';
 
 
@@ -16,6 +16,19 @@ const activeVersionId = ref(null);
 
 export function useMock() {
   const mockApi = {
+    log(message, logData = '') {
+      const { meta, configuration } = data;
+
+      const lines = [
+        `[Plugin: ${meta.configurator.name}] ${message}`,
+        `  projectId  =  ${meta.project.id}`,
+        `   designId  =  ${configuration.id}`,
+        `       user  =  ${meta.user.email}`
+      ]
+
+      console.log(lines.join('\n'));
+      if (logData) console.log('       data  = ', logData);
+    },
     setUrl() {},
     getUrl: () => window.location.hash.replace(/^#/, ''),
     getState: () => data.configuration.state,
@@ -26,8 +39,11 @@ export function useMock() {
       const { state } = activeVersion.value;
 
       each(patch, (val, key) => {
-        // Don't need to handle undefined values in localStorage
-        set(state, key, val);
+        if (val === undefined) {
+          unset(state, key);
+        } else {
+          set(state, key, val);
+        }
       });
 
       data.configuration.state = state;

--- a/core/store/index.js
+++ b/core/store/index.js
@@ -12,6 +12,7 @@ import useAppInfo from '../composables/useAppInfo.js';
 import useVersions from '../composables/useVersions';
 import { useHost } from '../plugins/host';
 import { useLeviateStore } from './leviate';
+import { checkEntitiesIntegrity } from './storeUtils';
 
 class TransactionError extends Error {
   constructor() {
@@ -39,13 +40,31 @@ async function decompressState(state) {
   return decompress(state);
 }
 
-function transact(cb) {
+async function hostSetState(newState) {
+  const stateToSave = _useStateCompression
+    ? await compressState(newState)
+    : { ...newState, _compressed: undefined };
+
+  const { activeVersionId } = useVersions();
+  return useHost().setState(stateToSave, activeVersionId.value);
+}
+
+function transact(nameOrCallback, callback, options = { skipRevision: false }) {
   if (useMeta().isReadOnly) {
     logger.log('Transaction skipped: Read-only mode.');
     return;
   }
 
-  return useRootStore().transact(cb);
+  let cb = callback;
+  let name = nameOrCallback;
+
+  if (typeof nameOrCallback !== 'string') {
+    logger.warn('legacy transact detected. Transaction will still run but in future you should use `transact(name, callback) for improved logging and debugging`');
+    cb = nameOrCallback;
+    name = 'Anonymous transaction';
+  }
+
+  return useRootStore().transact(name, cb, options);
 }
 
 const initialState = {
@@ -107,7 +126,7 @@ function deepDiff(obj1, obj2) {
 }
 
 const initialActions = {
-  async transact(cb) {
+  async transact(name, cb, options) {
     if (this.transactionDepth === 0) {
       transactionUpdates = [];
     }
@@ -133,27 +152,30 @@ const initialActions = {
 
       const diff = deepDiff(oldState, newState);
 
-      const stateToSave = _useStateCompression
-        ? await compressState(newState)
-        : { ...diff.newValue, _compressed: undefined };
+      const stateToSave = _useStateCompression ? newState : diff.newValue;
+      const updateKeys = { keys: Object.keys(stateToSave) };
 
-      const { activeVersionId } = useVersions();
-      useHost().setState(stateToSave, activeVersionId.value);
+      useHost().log?.(`Running transaction "${name}" for fields:`, updateKeys);
+
       transactionUpdates.unshift(diff);
+      hostSetState(stateToSave);
 
-      if (this.transactionDepth === 0) {
+      if (this.transactionDepth === 0 && !options.skipRevision) {
         this.revision.commit(transactionUpdates, transactionId);
       }
 
+      useHost().log?.(`Transaction "${name}" completed successfully`, updateKeys);
+
       return res;
     } catch (e) {
-      this._onTransactionError(e, transactionId, oldState);
+      this._onTransactionError(e, name, transactionId, oldState);
       return false;
     }
   },
 
-  _onTransactionError(e, transactionId, oldState) {
+  _onTransactionError(e, name, transactionId, oldState) {
     if (!(e instanceof TransactionError)) {
+      useHost().log?.(`Transaction "${name}" failed`);
       logger.error('transaction failed -', e);
     }
 
@@ -164,7 +186,7 @@ const initialActions = {
       if (transactionId === this.revision.transactionId) {
         this.revision.undo();
       } else {
-        this.replaceState(oldState);
+        this.replaceState(oldState, true);
       }
 
       useLeviateStore().setGlobalMessage(useLocalize().$L('error_global'));
@@ -188,7 +210,7 @@ const initialActions = {
     this.modules[useStore.$id] = useStore;
   },
 
-  replaceState(newState) {
+  replaceState(newState, shouldSync = false) {
     const rootState = {};
 
     Object.entries(newState).forEach(([key, value]) => {
@@ -207,6 +229,10 @@ const initialActions = {
     });
 
     this.$patch(rootState);
+
+    if (shouldSync) {
+      hostSetState(newState);
+    }
   },
 
   toJSON() {
@@ -370,9 +396,17 @@ function performMigration(rootStore, initialState, migrations) {
       migratedState = migration.migrateToLatest();
       logger.log(`successfully migrated to latest: ${latestMigrationName}`);
     }
-    rootStore.replaceState(migratedState || initialState);
+    rootStore.replaceState(migratedState || initialState, true);
   } else {
-    rootStore.$patch({ serialization_version: latestMigrationName });
+    transact('Set serialization version', () => {
+      rootStore.$patch({ serialization_version: latestMigrationName });
+    }, { skipRevision: true });
+  }
+
+  const modifiedEntities = checkEntitiesIntegrity(rootStore);
+
+  if (modifiedEntities) {
+    hostSetState({ entities: modifiedEntities });
   }
 }
 

--- a/core/store/index.js
+++ b/core/store/index.js
@@ -139,7 +139,7 @@ const initialActions = {
 
       const { activeVersionId } = useVersions();
       useHost().setState(stateToSave, activeVersionId.value);
-      transactionUpdates.unshift({ id: transactionId, ...diff });
+      transactionUpdates.unshift(diff);
 
       if (this.transactionDepth === 0) {
         this.revision.commit(transactionUpdates, transactionId);

--- a/core/store/leviate.ts
+++ b/core/store/leviate.ts
@@ -4,6 +4,8 @@ export type PanelNames = 'project' | 'input' | 'results' | 'validation'
 
 export const useLeviateStore = defineStore('leviate', {
   state: () => ({
+    globalMessage: null,
+    globalMessageTimeout: null,
     panels: {
       project: {
         isExpanded: true,
@@ -23,6 +25,17 @@ export const useLeviateStore = defineStore('leviate', {
     },
   }),
   actions: {
+    setGlobalMessage(message) {
+      clearTimeout(this.globalMessageTimeout);
+
+      this.globalMessage = message;
+
+      const displayMessageForMs = 4000;
+
+      this.globalMessageTimeout = setTimeout(() => {
+        this.globalMessage = null;
+      }, displayMessageForMs)
+    },
     setPanelIsExpanded(panelName: PanelNames, value: boolean) {
       this.panels[panelName].isExpanded = value;
     },

--- a/core/store/storeUtils.js
+++ b/core/store/storeUtils.js
@@ -1,0 +1,93 @@
+import { each } from 'lodash-es';
+
+function deleteEntitiesWithNoId(entitiesState) {
+  let isModified = false;
+
+  each(entitiesState, entities => {
+    each(entities.dataById, (entity, id) => {
+      if (!entity.id) {
+        isModified = true;
+        delete entities.dataById[id];
+      }
+    });
+  });
+
+  return isModified;
+}
+
+function checkLayerForObsoletePositions(entitiesState) {
+  const positions = entitiesState.positions.dataById;
+  const layers = entitiesState.layers.dataById;
+
+  let isModified = false;
+
+  each(layers, layer => {
+    const positionIdsToDeleteFromLayer = [];
+
+    layer.orderedPositionIds.forEach(id => {
+      if (!positions[id]) {
+        positionIdsToDeleteFromLayer.push(id);
+      }
+    });
+
+    // Remove from orderedPositionIds if position with id does not exist
+    if (positionIdsToDeleteFromLayer.length > 0) {
+      layer.orderedPositionIds = layer.orderedPositionIds.filter(id => {
+        return !positionIdsToDeleteFromLayer.includes(id);
+      });
+
+      isModified = true;
+    }
+  });
+
+  return isModified;
+}
+
+function addOrphanedPositionsToLayer(entitiesState) {
+  const positions = entitiesState.positions.dataById;
+  const layers = entitiesState.layers.dataById;
+
+  let isModified = false;
+
+  each(positions, (position, id) => {
+    const layer = layers[position.layerId];
+    const layerPositionIds = entitiesState.positions.idsByForeignKey.layerId[layer.id];
+
+    // Can't find layer relation so delete position
+    if (!layer || !layerPositionIds.includes(id)) {
+      delete position[id];
+      isModified = true;
+    }
+
+    const isMissingFromLayer = !layer.orderedPositionIds.includes(id);
+
+    if (isMissingFromLayer) {
+      layer.orderedPositionIds.push(id);
+      isModified = true;
+    }
+  });
+
+  return isModified;
+}
+
+/**
+ * Returns null if no modifications needed to be made, or the modified entities state if updates were made
+ * @param rootStore
+ * @returns {*|null}
+ */
+export function checkEntitiesIntegrity(rootStore) {
+  const allEntities = rootStore.modules.entities().$state;
+
+  // Delete any entity that doesn't have an id property as
+  // a result of transact failing when creating entities
+  let isModified = deleteEntitiesWithNoId(allEntities);
+
+  if (allEntities.layers && allEntities.positions) {
+    const hasRemovedObsoletePositions = checkLayerForObsoletePositions(allEntities);
+    const hasModifiedOrphanedPositions = addOrphanedPositionsToLayer(allEntities);
+
+    if (!isModified) isModified = hasRemovedObsoletePositions || hasModifiedOrphanedPositions;
+  }
+
+  return isModified ? allEntities : null;
+}

--- a/template/project/src/components/project/explorer/ProjectEntity.vue
+++ b/template/project/src/components/project/explorer/ProjectEntity.vue
@@ -35,11 +35,11 @@ const items = computed(() => props.model.read());
 const addItem = () => {
   const { model } = props;
 
-  transact(() => {
+  transact('Create entity', () => {
     const newItem = model.create();
 
     router.replace(`/entities/${model.id}/${newItem.id}`);
-  });
+  }, { skipRevision: true });
 };
 
 

--- a/template/project/src/components/project/explorer/ProjectEntityItem.vue
+++ b/template/project/src/components/project/explorer/ProjectEntityItem.vue
@@ -36,12 +36,11 @@ const route = useRoute();
 const props = defineProps({
   item: Object,
 });
-const { item } = props;
-const model = item.constructor;
+const model = props.item.constructor;
 
 const isEditing = ref(false);
 const inputRef = ref(null);
-const isActive = computed(() => route.params.id === item.id);
+const isActive = computed(() => route.params.id === props.item.id);
 
 const getItemRoute = (itemId) => `/entities/${model.id}/${itemId}`;
 
@@ -62,12 +61,14 @@ const onEnter = () => {
 };
 
 const onBlur = () => {
-  item.name = inputRef.value.innerHTML;
+  transact(() => {
+    props.item.name = inputRef.value.innerHTML;
+  });
 };
 
 const onClone = () => {
   transact(() => {
-    const newData = omit(item.$toJSON(), ['id', 'name']);
+    const newData = omit(props.item.$toJSON(), ['id', 'name']);
     const newItem = model.create(newData);
 
     router.push(getItemRoute(newItem.id));
@@ -76,8 +77,8 @@ const onClone = () => {
 
 const onDelete = () => {
   transact(() => {
-    item.$delete();
-  })
+    props.item.$delete();
+  });
 };
 
 </script>

--- a/template/project/src/mock.config.js
+++ b/template/project/src/mock.config.js
@@ -46,6 +46,7 @@ export default {
 
     user: {
       name: 'Wilt Chamberlain',
+      email: 'wilt@somewhere.com',
       locale: 'en',
       role: {
         name: 'admin',

--- a/template/project/src/store/index.js
+++ b/template/project/src/store/index.js
@@ -1,11 +1,22 @@
+import { transact } from '@crhio/leviate';
 import { useCalculationStore } from './calculation';
 import { useDocumentStore } from './documents';
 import { useSettingsStore } from './settings.js';
+import ExampleModel from '@/models/ExampleModel';
 
 export default {
   state: {},
-  actions: {},
+  actions: {
+    initialize() {
+      if (ExampleModel.read().length === 0) {
+        transact('Create initial model', () => {
+          ExampleModel.create();
+        }, { skipRevision: true });
+      }
+    }
+  },
   getters: {},
+  // Include only modules which require data persistence
   modules: [
     useSettingsStore,
     useCalculationStore,


### PR DESCRIPTION
- fix: revert changes if transaction fails
- feat: add skipRevision option to transact, in order to persist data
without adding an entry to the undo/redo history
- feat: use new host.log method to log transactions and add method to host mock
- fix: ensure undo/redo changes are persisted
- fix: check initial state and process corrupted entities