### PR TITLE
fix: remove redundunt location update check for circ feature

### DIFF
--- a/core/drawing/components/DFeatureCirc.vue
+++ b/core/drawing/components/DFeatureCirc.vue
@@ -122,12 +122,8 @@ function onDragAnchor(anchor: AvailableAnchorPoints | number, isDragComplete?: b
 
 watch(
   () => props.params.location,
-  (newLocation, prevLocation) => {
-    if (isEqual(prevLocation, newLocation)) return;
-
-    location.value = newLocation;
-  }
-);
+  (newLocation) => location.value = newLocation
+)
 
 watch(
   () => props.params.diameter,


### PR DESCRIPTION
in scope of [LA-110](https://crhleviat.atlassian.net/browse/LA-110)
that additional check on location update didn't let 'snap' functionality for Circular features moved out of the panel to work

[LA-110]: https://crhleviat.atlassian.net/browse/LA-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ