### PR TITLE
fix: update polycurves to polyfaces before feature validation

### DIFF
--- a/core/drawing/types/Sketch.ts
+++ b/core/drawing/types/Sketch.ts
@@ -84,6 +84,7 @@ export interface Sketch {
     z: (index: number) => Sketch;
     rotate: (angle: number, units?: string) => Sketch;
     clone: () => Sketch;
+    close: () => Sketch;
     extents: Extents;
     /**
      * Adds a rectangle to a sketch. A rectangle is a "polyface"--a closed chain of segments and arcs.


### PR DESCRIPTION
Polycurves fail validation, so polycurves should be closed (turned to polyfaces) prior to validation